### PR TITLE
The INMP441 needs 2^18 cycles to warmup according to the datasheet.

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -15,6 +15,9 @@
  #define I2S_SD 32        // aka DOUT
  #define I2S_SCK 14       // aka BCLK
 
+// INMP441 needs this amount of cycles to become operational
+ #define INMP441_SETUP_CYCLES 262144 // 2^18
+
 #ifdef ESP32
   #include <driver/i2s.h>
   const i2s_port_t I2S_PORT = I2S_NUM_0;
@@ -310,8 +313,7 @@ void agcAvg() {                                                     // A simple 
 
 #endif
 
-void logAudio() {
-
+void logAudio() { 
 #ifdef MIC_SAMPLING_LOG
   //------------ Oscilloscope output ---------------------------
     Serial.print(targetAgc); Serial.print(" ");

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -51,8 +51,14 @@ void userSetup()
     }
     Serial.println("I2S driver installed.");
 
-  delay(100);
+  // according to the nnmp441 datasheet, the chips need 2^18 SCK clock cycles to become operational.
+  // sck is is sample_rate(Hz) X bits_per_sample X channels
+  // for the defaults 32bit/10240hz/2 channel this results in a SCLK of 655Khz
+  // IDF 3.3 exposes i2s_get_clk 
 
+  uint16_t inmp441_setup_time_ms = (INMP441_SETUP_CYCLES*1000) / (i2s_config.sample_rate * i2s_config.bits_per_sample * 2);
+
+  delay(inmp441_setup_time_ms); 
 
   // Test to see if we have a digital microphone installed or not.
 


### PR DESCRIPTION
According to the specs ( https://invensense.tdk.com/wp-content/uploads/2015/02/INMP441.pdf ) 
The INMP441 has zero output for the first 262144 cycles following powerup.

This means the default of 100 miliseconds is far from enough.

(I noticed because a cold booted esp32 failed to recognize the microphone. After a soft reset the microphone was detected)

Tested on an esp-wroom-32 (mh)