### PR TITLE
Improves segment handling for some sound-reactive effects.

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4365,14 +4365,14 @@ uint16_t WS2812FX::mode_gravimeter(void) {                // Gravmeter. By Andre
 
   fade_out(240);
 
-  sampleAvg = sampleAvg * SEGMENT.intensity / 255;
+  float segmentSampleAvg = sampleAvg * SEGMENT.intensity / 255;
 
-  int tempsamp = constrain(sampleAvg*2,0,SEGLEN-1);       // Keep the sample from overflowing.
+  int tempsamp = constrain(segmentSampleAvg*2,0,SEGLEN-1);       // Keep the sample from overflowing.
   uint8_t gravity = 8 - SEGMENT.speed/32;
 
   for (int i=0; i<tempsamp; i++) {
-    uint8_t index = inoise8(i*sampleAvg+millis(), 5000+i*sampleAvg);
-    setPixelColor(i, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), sampleAvg*8));
+    uint8_t index = inoise8(i*segmentSampleAvg+millis(), 5000+i*segmentSampleAvg);
+    setPixelColor(i, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), segmentSampleAvg*8));
   }
 
   if (tempsamp >= gravcen->topLED)
@@ -4401,15 +4401,15 @@ uint16_t WS2812FX::mode_gravcenter(void) {                // Gravcenter. By Andr
 
   fade_out(240);
 
-  sampleAvg = sampleAvg * SEGMENT.intensity / 255;
+  float segmentSampleAvg = sampleAvg * SEGMENT.intensity / 255;
 
-  int tempsamp = constrain(sampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
+  int tempsamp = constrain(segmentSampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
   uint8_t gravity = 8 - SEGMENT.speed/32;
 
   for (int i=0; i<tempsamp; i++) {
-    uint8_t index = inoise8(i*sampleAvg+millis(), 5000+i*sampleAvg);
-    setPixelColor(i+SEGLEN/2, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), sampleAvg*8));
-    setPixelColor(SEGLEN/2-i-1, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), sampleAvg*8));
+    uint8_t index = inoise8(i*segmentSampleAvg+millis(), 5000+i*segmentSampleAvg);
+    setPixelColor(i+SEGLEN/2, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), segmentSampleAvg*8));
+    setPixelColor(SEGLEN/2-i-1, color_blend(SEGCOLOR(1), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), segmentSampleAvg*8));
   }
 
   if (tempsamp >= gravcen->topLED)
@@ -4440,13 +4440,13 @@ uint16_t WS2812FX::mode_gravcentric(void) {               // Gravcenter. By Andr
   fade_out(240);
   fade_out(240);
 
-  sampleAvg = sampleAvg * SEGMENT.intensity / 255;
+  float segmentSampleAvg = sampleAvg * SEGMENT.intensity / 255;
 
-  int tempsamp = constrain(sampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
+  int tempsamp = constrain(segmentSampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
   uint8_t gravity = 8 - SEGMENT.speed/32;
 
   for (int i=0; i<tempsamp; i++) {
-    uint8_t index = sampleAvg*24+millis()/200;
+    uint8_t index = segmentSampleAvg*24+millis()/200;
     setPixelColor(i+SEGLEN/2, color_blend(SEGCOLOR(0), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), 255));
     setPixelColor(SEGLEN/2-1-i, color_blend(SEGCOLOR(0), color_from_palette(index, false, PALETTE_SOLID_WRAP, 0), 255));
   }
@@ -5003,9 +5003,9 @@ uint16_t WS2812FX::mode_gravfreq(void) {                  // Gravfreq. By Andrew
 
   fade_out(240);
 
-  sampleAvg = sampleAvg * SEGMENT.intensity / 255;
+  float segmentSampleAvg = sampleAvg * SEGMENT.intensity / 255;
 
-  int tempsamp = constrain(sampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
+  int tempsamp = constrain(segmentSampleAvg*2,0,SEGLEN/2);     // Keep the sample from overflowing.
   uint8_t gravity = 8 - SEGMENT.speed/32;
 
   for (int i=0; i<tempsamp; i++) {


### PR DESCRIPTION
WLED and this sound reactive fork are amazing! Thank you so much for making this accessible to everyone. I noticed what I think is a tiny bug playing with the effects on a multi-segment display:

Effects which scaled the sampleAvg to the segment intensity were mutating the global variable storing the sound level, so each segment in turn re-applied the intensity scaling. This meant that when the intensity was not at 100%, these effects would quickly attenuate. In practice this meant that effects like Grav Center were only visible on one segment when not at full intensity. I just added a locally scoped var to each effect to temporarily hold the scaled sampleAvg while processing each segment, and it seems to have made things work the way I expected: the range of intensity is limited, but applied equally to each segment, so they all mirror the same effect.