### PR TITLE
Fixes enable digital mic runtime setting ignored

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -281,7 +281,7 @@ void FFTcode( void * parameter) {
     //extern double volume;   // COMMENTED OUT - UNUSED VARIABLE COMPILER WARNINGS
 
     for(int i=0; i<samples; i++) {
-      if (digitalMic == false) {
+      if (digitalMic && dmEnabled == false) {
         micData = analogRead(audioPin);           // Analog Read
       } else {
         int32_t digitalSample = 0;
@@ -303,7 +303,7 @@ void FFTcode( void * parameter) {
       // DEBUGSR_PRINT(micDataSm);
       // DEBUGSR_PRINT("\n");
 
-      if (digitalMic == false) { while(micros() - microseconds < sampling_period_us){/*empty loop*/} }
+      if (digitalMic && dmEnabled == false) { while(micros() - microseconds < sampling_period_us){/*empty loop*/} }
 
       microseconds += sampling_period_us;
     }


### PR DESCRIPTION
Unchecking "enable digital mic" in Config >> Sound Settings,  did not enable the analog mic.
Sampling routine only checked for detected digital mic presence at boot.
Since sometimes a digital mic is detected, even if not present, this rendered analog mic not useable in some cases.