### PR TITLE
Initial ES7243 Mic Support

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -40,7 +40,11 @@
 const i2s_port_t I2S_PORT = I2S_NUM_0;
 const int BLOCK_SIZE = 64;
 
-const int SAMPLE_RATE = 10240;                  // Base sample rate in Hz
+#ifdef USE_ES7243
+  const int SAMPLE_RATE = 11025;                  // Base sample rate in Hz
+#else
+  const int SAMPLE_RATE = 10240;                  // Base sample rate in Hz
+#endif // USE_ES7243
 
 //Use userVar0 and userVar1 (API calls &U0=,&U1=, uint16_t)
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -310,6 +310,12 @@ void WLED::setup()
   pinManager.allocatePin(2, true, PinOwner::DMX);
 #endif
 
+#ifdef USE_ES7243 // SET GPIO0 as Master Clock
+  pinManager.allocatePin(0, true);
+  WRITE_PERI_REG(PIN_CTRL, 0xFF0); // Tell ESP to put CLK1 out to GPIO0
+  PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1); // Tell GPIO0 that it's CLK1
+#endif // USE_ES7243
+
   DEBUG_PRINTLN(F("Registering usermods ..."));
   registerUsermods();
 


### PR DESCRIPTION
The ES7243 I2S mic is on the LyraT Mini dev board and on the Wyze Light Strip controller (PWM) and presumably on their Wyze Light Strip Pro controller (addressable). The microphone requires both an I2C based setup step and a Master Clock. 

I am still tracking down the details of the I2C setup step (so that different settings can be accommodated such as different gains), but I have currently implemented the settings used in the ESP-ADF for the LyraT Mini, and it works well on my device, though further testing may be requires on the FFT side of things (tuning so equivalent behavior between this mic and existing configurations is attained).

The entire change is wrapped in the compile flag `USE_ES7243`. So, nothing is affected by default.

Tested with this build environment
```ini
[env:soundReactive_WyzePWM]
board = esp32dev
platform = espressif32@3.2
upload_speed = 921600
build_unflags = ${common.build_unflags}
lib_deps = ${esp32.lib_deps}
board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
build_flags = ${common.build_flags_esp32}
   -D WLED_USE_MY_CONFIG
   -D WLED_MAX_BUTTONS=2
   -D BTNPIN=19
  ;  -D RLYPIN=13 ; This is a status LED not Relay. It's an orange LED to have on when strip off.
  ;  -D RLYMDE=0
   -D USE_ES7243 ; assumes master clock on GPIO0
   -D ES7243_ADDR=0x13
   -D ES7243_SDAPIN=18
   -D ES7243_SCLPIN=23
   -D I2S_SDPIN=36
   -D I2S_CKPIN=32
   -D I2S_WSPIN=33
   -D AUDIOPIN=-1
   -D STATUSLED=13
; There's a second button on 2 and a second status LED on 15.
```