### PR TITLE
Basic I2S support for ESP8266

### DIFF
--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -14,10 +14,23 @@
  * Not 100% sure this was done right. There is probably a better way to handle this...
  */
 
+#ifdef ESP8266_I2S
+#include <i2s.h>
+#endif // ESP8266_I2S
 
 // This gets called once at boot. Do all initialization that doesn't depend on network here
 void userSetup()
 {
+#ifdef ESP8266_I2S
+  delay(100); // give mic some time like on 32 branch
+  i2s_rxtx_begin(true, false); // RX = true, TX = false.
+                               // ESP866 I2S is a fixed pin configuration.
+                               //   DATA      GPIO12
+                               //   BCK/SCK   GPIO13
+                               //   WS/LRCLK  GPIO14.
+                               // Tested on INMP441 with grounded L/R (choosing L).
+  i2s_set_rate(SAMPLE_RATE);
+#endif // ESP8266_I2S
 }
 
 // This gets called every time WiFi is (re-)connected. Initialize own network interfaces here

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -315,6 +315,12 @@ void WLED::setup()
   DEBUG_PRINTLN(F("Reading config"));
   deserializeConfigFromFS();
 
+#if ESP8266_I2S
+  pinManager.allocatePin(12); // SD/DIN/Data
+  pinManager.allocatePin(13); // BCK/SCK
+  pinManager.allocatePin(14); // WS/LRCLK
+#endif //ESP8266_I2S
+
 #if STATUSLED
   if (!pinManager.isPinAllocated(STATUSLED)) {
     // NOTE: Special case: The status LED should *NOT* be allocated.


### PR DESCRIPTION
This adds basic I2S support to ESP8266 just to get a maybe more reliable input than the ADC. Tested on a NodeMCU using an INMP441 with L/R grounded and 200 fairy lights on GPIO2.

All changes wrapped in directive `ESP8266_I2S` so there are no checks to fall back to analog.

The I2S config on ESP8266 is fixed
```
DATA      GPIO12
BCK/SCK   GPIO13
WS/LRCLK  GPIO14
```

Environment used in testing
```ini
[env:soundReactive_nodemcuv2_i2s]
extends = env:soundReactive_nodemcuv2
build_flags = ${common.build_flags_esp8266}
   -D ESP8266_I2S
```

Adds 2,252 bytes to flash.