### PR TITLE
Fix race condition when switching between mic types

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -287,7 +287,7 @@ void FFTcode( void * parameter) {
     for(int i=0; i<samples; i++) {
       if (dmEnabled == 0) {
         micData = analogRead(audioPin) >> 2;           // Analog Read
-      } else {
+      } else if (!doReboot) {
         int32_t digitalSample = 0;
         size_t bytes_read = 0;
         esp_err_t result = i2s_read(I2S_PORT, &digitalSample, sizeof(digitalSample), &bytes_read, /*portMAX_DELAY*/ 10);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -571,14 +571,14 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       audioPin = audioPin;
     }
     // Digital mic mode
-    uint8_t oldDMEnabled = dmEnabled;
-    dmEnabled = request->arg(F("DMM")).toInt();
+    uint8_t newDMEnabled = request->arg(F("DMM")).toInt();
     // If the mic type was changed, reboot! ToDo: we don't need to reboot
     // we just need to reload the I2S code to set up the proper mic. For
     // now, a reboot is the simple solution.
-    if (oldDMEnabled != dmEnabled) {
+    if ((dmEnabled == 0) && (newDMEnabled == 1)) {
       doReboot = true;
     }
+    dmEnabled = newDMEnabled;
     // Digital Mic I2S SD pin
     int hw_i2ssd_pin = request->arg(F("DI")).toInt();
     if (pinManager.allocatePin(hw_i2ssd_pin,false)) {


### PR DESCRIPTION
Fix a race condition that would cause panics because the FFTTask manages to reach i2s_read before the reboot actually happened. Remove reboots when changing TO analog mics