### PR TITLE
ESP8266 I2S remove abs on read.

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -101,9 +101,9 @@ void getSample() {
   #ifdef WLED_DISABLE_SOUND
     micIn = inoise8(millis(), millis());          // Simulated analog read
   #else
-    #ifdef ESP8266_I2S
+    #ifdef ESP8266_I2S // test sketch: https://pastebin.com/SVqWGxrH
       i2s_read_sample(&micIn_L, &micIn_R, true);
-      micIn = abs(micIn_L); // 16 bit read, could have >> 6 to match analogRead's 10 bit, but in my testing, the range is pretty close to the ADC even with 16 bit.
+      micIn = micIn_L; // 16 bit read, could have >> 6 to match analogRead's 10 bit, but in my testing, the range is pretty close to the ADC even with 16 bit.
     #else
       micIn = analogRead(MIC_PIN);                  // Poor man's analog read
     #endif


### PR DESCRIPTION
Tiny change but open for discussion on this.

The ESP32 code does an abs on the mic data directly after reading, but then it is doing a whole lot of FFT stuff the ESP8266 isn't ever going to do. The issue I see with the immediate abs is that the micLev calculations don't make much sense if your data is already centered at 0 then pre-applied an abs.  So, the center the micLev finds isn't actually a center. After a few days away from the initial implementation and looking and testing again, things seems to make more sense without the abs.