### PR TITLE
activate correct preset after boot - scanning back through time schedule

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4940,11 +4940,14 @@ uint16_t WS2812FX::mode_2DLissajous(void) {            // By: Andrew Tuline
 //    2D Matrix      //
 ///////////////////////
 
-uint16_t WS2812FX::mode_2Dmatrix(void) {                  // Matrix2D. By Jeremy Williams. Adapted by Andrew Tuline.
+uint16_t WS2812FX::mode_2Dmatrix(void) {                  // Matrix2D. By Jeremy Williams. Adapted by Andrew Tuline & improved by merkisoft.
 
   if (SEGENV.call == 0) fill_solid(leds, 0);
 
-  if (millis() - SEGENV.step >= ((256-SEGMENT.speed) >>2)) {
+  int fade = map(SEGMENT.fft1, 0, 255, 50, 250);    // equals trail size
+  int speed = (256-SEGMENT.speed) >> map(MIN(SEGMENT.height, 150), 0, 150, 0, 3);    // slower speeds for small displays
+
+  if (millis() - SEGENV.step >= speed) {
     SEGENV.step = millis();
 //    if (SEGMENT.fft3 < 128) {									            // check for orientation, slider in first quarter, default orientation
     	for (int16_t row=SEGMENT.height-1; row>=0; row--) {
@@ -4958,7 +4961,7 @@ uint16_t WS2812FX::mode_2Dmatrix(void) {                  // Matrix2D. By Jeremy
 
     // fade all leds
     for (int x=0; x<SEGMENT.width; x++) for (int y=0; y<SEGMENT.height; y++) { // ewowi20210629: change to segment width/height
-      if (leds[XY(x,y)].g != 255) leds[XY(x,y)].nscale8(192);         // only fade trail
+      if (leds[XY(x,y)].g != 255) leds[XY(x,y)].nscale8(fade);         // only fade trail
     }
 
     // check for empty screen to ensure code spawn

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -1407,7 +1407,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "2D Squared Swirl@,,,,Blur;,,;!",
 "2D Fire2012@Speed;;",
 "2D DNA@Scroll speed,Blur;;!",
-"2D Matrix@Falling speed,Spawning rate;;",
+"2D Matrix@Falling speed,Spawning rate,Trail;;",
 "2D Metaballs@;;",
 " ♫ Freqmap@Fade rate,Starting color;,!;!",
 " ♪ Gravcenter@Rate of fall,Sensitivity;,!;!",


### PR DESCRIPTION
this will enable power saving over the night or during the day, when the light is not needed.
@atuline hopefully you will like this improvement and merge it soon!

currently this is only done once after booting when the first proper ntp time is received.
ideally this would also happen after the preset schedule is saved ... maybe i will look into this in a next step

