### PR TITLE
Small QoL updates, fix WLED OTA

### DIFF
--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     // Private constructor, to make sure it is not callable except from derived classes
-    AudioSource(int sampleRate, int blockSize, uint16_t lshift, uint32_t mask) : _sampleRate(sampleRate), _blockSize(blockSize), _sampleNoDCOffset(0), _dcOffset(0.0f), _shift(lshift), _mask(mask) {};
+    AudioSource(int sampleRate, int blockSize, uint16_t lshift, uint32_t mask) : _sampleRate(sampleRate), _blockSize(blockSize), _sampleNoDCOffset(0), _dcOffset(0.0f), _shift(lshift), _mask(mask), _initialized(false) {};
 
     int _sampleRate;                /* Microphone sampling rate */
     int _blockSize;                 /* I2S block size */
@@ -76,7 +76,7 @@ protected:
     float _dcOffset;                /* Rolling average DC offset */
     uint16_t _shift;                /* Shift obtained samples to the right by this amount */
     uint32_t _mask;                 /* Bitmask for sample data after shifting */
-
+    bool _initialized;              /* Gets set to true if initialization is successful */
 };
 
 /* Basic I2S microphone source
@@ -106,59 +106,72 @@ public:
     };
 
 
+
+
     virtual void initialize() {
+
+        if (!pinManager.allocatePin(i2sckPin, true, PinOwner::DigitalMic) ||
+            !pinManager.allocatePin(i2swsPin, true, PinOwner::DigitalMic) ||
+            !pinManager.allocatePin(i2ssdPin, true, PinOwner::DigitalMic)) {
+                return;
+            }
 
         esp_err_t err = i2s_driver_install(I2S_NUM_0, &_config, 0, nullptr);
         if (err != ESP_OK) {
             Serial.printf("Failed to install i2s driver: %d\n", err);
-            while (true);
+            return;
         }
 
         err = i2s_set_pin(I2S_NUM_0, &_pinConfig);
         if (err != ESP_OK) {
             Serial.printf("Failed to set i2s pin config: %d\n", err);
-            while (true);
+            return;
         }
+
+        _initialized = true;
     }
 
     virtual void deinitialize() {
+        _initialized = false;
         esp_err_t err = i2s_driver_uninstall(I2S_NUM_0);
         if (err != ESP_OK) {
             Serial.printf("Failed to uninstall i2s driver: %d\n", err);
-            while (true);
+            return;
         }
     }
 
     virtual void getSamples(double *buffer, uint16_t num_samples) {
-        esp_err_t err;
-        size_t bytes_read = 0;        /* Counter variable to check if we actually got enough data */
-        int32_t samples[num_samples]; /* Intermediary sample storage */
+        if(_initialized) {
+            esp_err_t err;
+            size_t bytes_read = 0;        /* Counter variable to check if we actually got enough data */
+            int32_t samples[num_samples]; /* Intermediary sample storage */
 
-        // Reset dc offset
-        _dcOffset = 0.0f;
+            // Reset dc offset
+            _dcOffset = 0.0f;
 
-        err = i2s_read(I2S_NUM_0, (void *)samples, sizeof(samples), &bytes_read, portMAX_DELAY);
-        if ((err != ESP_OK)){
-            Serial.printf("Failed to get samples: %d\n", err);
-            while(true);
+            err = i2s_read(I2S_NUM_0, (void *)samples, sizeof(samples), &bytes_read, portMAX_DELAY);
+            if ((err != ESP_OK)){
+                Serial.printf("Failed to get samples: %d\n", err);
+                return;
+            }
+
+            // For correct operation, we need to read exactly sizeof(samples) bytes from i2s
+            if(bytes_read != sizeof(samples)) {
+                Serial.printf("Failed to get enough samples: wanted: %d read: %d\n", sizeof(samples), bytes_read);
+                return;
+            }
+
+            // Store samples in sample buffer and update DC offset
+            for (int i = 0; i < num_samples; i++) {
+                // From the old code.
+                double sample = (double)abs((samples[i] >> _shift));
+                buffer[i] = sample;
+                _dcOffset = ((_dcOffset * 31) + sample) / 32;
+            }
+
+            // Update no-DC sample
+            _sampleNoDCOffset = abs(buffer[num_samples - 1] - _dcOffset);
         }
-
-        // For correct operation, we need to read exactly sizeof(samples) bytes from i2s
-        if(bytes_read != sizeof(samples)) {
-            Serial.printf("Failed to get enough samples: wanted: %d read: %d\n", sizeof(samples), bytes_read);
-            return;
-        }
-
-        // Store samples in sample buffer and update DC offset
-        for (int i = 0; i < num_samples; i++) {
-            // From the old code.
-            double sample = (double)abs((samples[i] >> _shift));
-            buffer[i] = sample;
-            _dcOffset = ((_dcOffset * 31) + sample) / 32;
-        }
-
-        // Update no-DC sample
-        _sampleNoDCOffset = abs(buffer[num_samples - 1] - _dcOffset);
     }
 
     virtual int getSampleWithoutDCOffset() {
@@ -182,7 +195,9 @@ public:
 
     virtual void initialize() {
         // Reserve the master clock pin
-        pinManager.allocatePin(mclkPin, true, PinOwner::DigitalMic);
+        if(!pinManager.allocatePin(mclkPin, true, PinOwner::DigitalMic)) {
+            return;
+        }
         _routeMclk();
         I2SSource::initialize();
 
@@ -248,8 +263,10 @@ public:
     };
     void initialize() {
         // Reserve SDA and SCL pins of the I2C interface
-        pinManager.allocatePin(pin_ES7243_SDA, true, PinOwner::DigitalMic);
-        pinManager.allocatePin(pin_ES7243_SCL, true, PinOwner::DigitalMic);
+        if (!pinManager.allocatePin(pin_ES7243_SDA, true, PinOwner::DigitalMic) ||
+            !pinManager.allocatePin(pin_ES7243_SCL, true, PinOwner::DigitalMic)) {
+                return;
+            }
 
         // First route mclk, then configure ADC over I2C, then configure I2S
         _es7243InitAdc();
@@ -286,11 +303,15 @@ public:
     }
 
     void initialize() {
+
+        if(!pinManager.allocatePin(audioPin, false, PinOwner::AnalogMic)) {
+            return;
+        }
         // Determine Analog channel. Only Channels on ADC1 are supported
         int8_t channel = digitalPinToAnalogChannel(audioPin);
         if (channel > 9) {
             Serial.printf("Incompatible GPIO used for audio in: %d\n", audioPin);
-            while (true);
+            return;
         } else {
             adc_gpio_init(ADC_UNIT_1, adc_channel_t(channel));
         }
@@ -299,35 +320,44 @@ public:
         esp_err_t err = i2s_driver_install(I2S_NUM_0, &_config, 0, nullptr);
         if (err != ESP_OK) {
             Serial.printf("Failed to install i2s driver: %d\n", err);
-            while (true);
+            return;
         }
 
         // Enable I2S mode of ADC
         err = i2s_set_adc_mode(ADC_UNIT_1, adc1_channel_t(channel));
         if (err != ESP_OK) {
             Serial.printf("Failed to set i2s adc mode: %d\n", err);
-            while (true);
+            return;
         }
+
+        _initialized = true;
     }
 
     void getSamples(double *buffer, uint16_t num_samples) {
 
-        /* Enable ADC. This has to be enabled and disabled directly before and
-           after sampling, otherwise Wifi dies
-        */
-        esp_err_t err = i2s_adc_enable(I2S_NUM_0);
-        if (err != ESP_OK) {
-            Serial.printf("Failed to enable i2s adc: %d\n", err);
-            while (true);
-        }
+    /* Enable ADC. This has to be enabled and disabled directly before and
+    after sampling, otherwise Wifi dies
+    */
+        if (_initialized) {
+            esp_err_t err = i2s_adc_enable(I2S_NUM_0);
+            if (err != ESP_OK) {
+                Serial.printf("Failed to enable i2s adc: %d\n", err);
+                return;
+            }
 
-        I2SSource::getSamples(buffer, num_samples);
+            I2SSource::getSamples(buffer, num_samples);
 
-        err = i2s_adc_disable(I2S_NUM_0);
-        if (err != ESP_OK) {
-            Serial.printf("Failed to disable i2s adc: %d\n", err);
-            while (true);
+            err = i2s_adc_disable(I2S_NUM_0);
+            if (err != ESP_OK) {
+                Serial.printf("Failed to disable i2s adc: %d\n", err);
+                return;
+            }
         }
+    }
+
+    void deinitialize() {
+        pinManager.deallocatePin(audioPin, PinOwner::AnalogMic);
+        I2SSource::deinitialize();
     }
 };
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -222,38 +222,41 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   // Sound Reactive Pin Config
   JsonObject analogmic = hw[F("analogmic")]; // analog mic JsonObject
 
-  int hw_amic_pin = analogmic[F("pin")];
-  if (pinManager.allocatePin(hw_amic_pin,false, PinOwner::AnalogMic)) {
-    audioPin = hw_amic_pin;
-  } else {
-    audioPin = audioPin;
-  }
+  // int hw_amic_pin = analogmic[F("pin")];
+  CJSON(audioPin, analogmic[F("pin")]);
+  // if (pinManager.allocatePin(hw_amic_pin,false, PinOwner::AnalogMic)) {
+  //   audioPin = hw_amic_pin;
+  // } else {
+  //   audioPin = audioPin;
+  // }
 
   JsonObject hw_dmic = hw[F("digitalmic")]; // digital mic JsonObject
   CJSON(dmEnabled, hw_dmic["en"]);
 
   JsonObject hw_dmic_pins = hw_dmic["pins"]; // digital mic pins JsonObject
 
-  int hw_i2ssd_pin = hw_dmic_pins[F("i2ssd")];
-  if (pinManager.allocatePin(hw_i2ssd_pin,false, PinOwner::DigitalMic)) {
-    i2ssdPin = hw_i2ssd_pin;
-  } else {
-    i2ssdPin = i2ssdPin;
-  }
+  CJSON(i2ssdPin, hw_dmic_pins[F("i2ssd")]);
+  // int hw_i2ssd_pin = hw_dmic_pins[F("i2ssd")];
+  // if (pinManager.allocatePin(hw_i2ssd_pin,false, PinOwner::DigitalMic)) {
+  //   i2ssdPin = hw_i2ssd_pin;
+  // } else {
+  //   i2ssdPin = i2ssdPin;
+  // }
+  CJSON(i2swsPin, hw_dmic_pins[F("i2sws")]);
+  // int hw_i2sws_pin = hw_dmic_pins[F("i2sws")];
+  // if (pinManager.allocatePin(hw_i2sws_pin,false, PinOwner::DigitalMic)) {
+  //   i2swsPin = hw_i2sws_pin;
+  // } else {
+  //   i2swsPin = i2swsPin;
+  // }
 
-  int hw_i2sws_pin = hw_dmic_pins[F("i2sws")];
-  if (pinManager.allocatePin(hw_i2sws_pin,false, PinOwner::DigitalMic)) {
-    i2swsPin = hw_i2sws_pin;
-  } else {
-    i2swsPin = i2swsPin;
-  }
-
-  int hw_i2sck_pin = hw_dmic_pins[F("i2sck")];
-  if (pinManager.allocatePin(hw_i2sck_pin,false, PinOwner::DigitalMic)) {
-    i2sckPin = hw_i2sck_pin;
-  } else {
-    i2sckPin = i2sckPin;
-  }
+  CJSON(i2sckPin, hw_dmic_pins[F("i2sck")]);
+  // int hw_i2sck_pin = hw_dmic_pins[F("i2sck")];
+  // if (pinManager.allocatePin(hw_i2sck_pin,false, PinOwner::DigitalMic)) {
+  //   i2sckPin = hw_i2sck_pin;
+  // } else {
+  //   i2sckPin = i2sckPin;
+  // }
 
   //int hw_status_pin = hw[F("status")]["pin"]; // -1
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -231,7 +231,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   // }
 
   JsonObject hw_dmic = hw[F("digitalmic")]; // digital mic JsonObject
-  CJSON(dmEnabled, hw_dmic["en"]);
+  CJSON(dmType, hw_dmic["en"]);
 
   JsonObject hw_dmic_pins = hw_dmic["pins"]; // digital mic pins JsonObject
 
@@ -683,7 +683,7 @@ void serializeConfig() {
   hw_amic["pin"] = audioPin;
 
   JsonObject hw_dmic = hw.createNestedObject("digitalmic");
-  hw_dmic["en"] = dmEnabled;
+  hw_dmic["en"] = dmType;
 
   JsonObject hw_dmic_pins = hw_dmic.createNestedObject("pins");
   hw_dmic_pins[F("i2ssd")] = i2ssdPin;

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -564,40 +564,54 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     if (t >=0) soundAgc = t;
 
     // Analog mic pin
-    int hw_amic_pin = request->arg(F("SI")).toInt();
-    if (pinManager.allocatePin(hw_amic_pin,false, PinOwner::AnalogMic)) {
-      audioPin = hw_amic_pin;
-    } else {
-      audioPin = audioPin;
-    }
-    // Digital mic mode
-    uint8_t newDMEnabled = request->arg(F("DMM")).toInt();
-    // If the mic type was changed, tell the user to reset the board!
-    if (dmEnabled != newDMEnabled) {
-      serveMessage(request, 200,F("Settings saved..."),F("Please reset the board for changes to take effect!"), 10);
-      dmEnabled = newDMEnabled;
-    }
+    // int hw_amic_pin = request->arg(F("SI")).toInt();
+    // if (pinManager.allocatePin(hw_amic_pin,false, PinOwner::AnalogMic)) {
+    //   audioPin = hw_amic_pin;
+    // } else {
+    //   audioPin = audioPin;
+    // }
+    t = request->arg(F("SI")).toInt();
+    if (t >= 0 && t <=39) audioPin = t;
+
     // Digital Mic I2S SD pin
-    int hw_i2ssd_pin = request->arg(F("DI")).toInt();
-    if (pinManager.allocatePin(hw_i2ssd_pin,false, PinOwner::DigitalMic)) {
-      i2ssdPin = hw_i2ssd_pin;
-    } else {
-      i2ssdPin = i2ssdPin;
-    }
+    t = request->arg(F("DI")).toInt();
+    if (t >= 0 && t <=39) i2ssdPin = t;
+
     // Digital Mic I2S WS pin
-    int hw_i2sws_pin = request->arg(F("LR")).toInt();
-    if (pinManager.allocatePin(hw_i2sws_pin,false, PinOwner::DigitalMic)) {
-      i2swsPin = hw_i2sws_pin;
-    } else {
-      i2swsPin = i2swsPin;
-    }
+    t = request->arg(F("LR")).toInt();
+    if (t >= 0 && t <=39) i2swsPin = t;
+
     // Digital Mic I2S SCK pin
-    int hw_i2sck_pin = request->arg(F("CK")).toInt();
-    if (pinManager.allocatePin(hw_i2sck_pin,false, PinOwner::DigitalMic)) {
-      i2sckPin = hw_i2sck_pin;
-    } else {
-      i2sckPin = i2sckPin;
+    t = request->arg(F("CK")).toInt();
+    if (t >= 0 && t <=39) i2sckPin = t;
+
+    // Digital mic mode
+    uint8_t newDmType = request->arg(F("DMM")).toInt();
+    // If the mic type was changed, tell the user to reset the board!
+    if (dmType != newDmType) {
+      serveMessage(request, 200,F("Settings saved..."),F("Please reset the board for changes to take effect!"), 10);
+      dmType = newDmType;
     }
+    // int hw_i2ssd_pin = request->arg(F("DI")).toInt();
+    // if (pinManager.allocatePin(hw_i2ssd_pin,false, PinOwner::DigitalMic)) {
+    //   i2ssdPin = hw_i2ssd_pin;
+    // } else {
+    //   i2ssdPin = i2ssdPin;
+    // }
+    // // Digital Mic I2S WS pin
+    // int hw_i2sws_pin = request->arg(F("LR")).toInt();
+    // if (pinManager.allocatePin(hw_i2sws_pin,false, PinOwner::DigitalMic)) {
+    //   i2swsPin = hw_i2sws_pin;
+    // } else {
+    //   i2swsPin = i2swsPin;
+    // }
+    // // Digital Mic I2S SCK pin
+    // int hw_i2sck_pin = request->arg(F("CK")).toInt();
+    // if (pinManager.allocatePin(hw_i2sck_pin,false, PinOwner::DigitalMic)) {
+    //   i2sckPin = hw_i2sck_pin;
+    // } else {
+    //   i2sckPin = i2sckPin;
+    // }
   }
 
   if (subPage != 2 && (subPage != 6 || !doReboot)) serializeConfig(); //do not save if factory reset or LED settings (which are saved after LED re-init)

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -21,7 +21,7 @@ void userSetup() {
   periph_module_reset(PERIPH_I2S0_MODULE);
 
   delay(100);         // Give that poor microphone some time to setup.
-  switch (dmEnabled) {
+  switch (dmType) {
     case 1:
       Serial.println("Attempting to configure generic I2S Microphone.");
       audioSource = new I2SSource(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -243,9 +243,9 @@ WLED_GLOBAL int8_t audioPin _INIT(36);
 WLED_GLOBAL int8_t audioPin _INIT(AUDIOPIN);
 #endif
 #ifndef DMENABLED // aka DOUT
-WLED_GLOBAL uint8_t dmEnabled _INIT(0);
+WLED_GLOBAL uint8_t dmType _INIT(0);
 #else
-WLED_GLOBAL uint8_t dmEnabled _INIT(DMENABLED);
+WLED_GLOBAL uint8_t dmType _INIT(DMENABLED);
 #endif
 #ifndef I2S_SDPIN // aka DOUT
 WLED_GLOBAL int8_t i2ssdPin _INIT(32);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -693,7 +693,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("GN"),sampleGain);
     sappend('c',SET_F("AGC"),soundAgc);
     sappend('v',SET_F("SI"),audioPin);
-    sappend('i',SET_F("DMM"),dmEnabled);
+    sappend('i',SET_F("DMM"),dmType);
     sappend('v',SET_F("DI"),i2ssdPin);
     sappend('v',SET_F("LR"),i2swsPin);
     sappend('v',SET_F("CK"),i2sckPin);


### PR DESCRIPTION
Changes:

- Move pin allocation from the config functions to the mic initialization, 
- remove the blocking loops that would keep wled from coming up if mic initialization fails, and 
- use the proper API to deserialize SR related parameters from cfg.json, which hopefully improves people updating from WLED AC using OTA
- Rename dmEnabled to dmType, remove pinallocs from settings system