### PR TITLE
platformio.ini: Remove old AsyncTCP

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -163,7 +163,6 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    AsyncTCP @ 1.0.3 ;Stutter fix
     fastled/FastLED @ 3.4.0
     IRremoteESP8266 @ 2.7.18
     https://github.com/lorol/LITTLEFS.git


### PR DESCRIPTION
An old version of AsyncTCP was being pulled in, which caused corrupt heap errors when used together with the new audio source. Remove the line, so the new version (1.2.0 from  pbolduc gets pulled in again)