### PR TITLE
Add M5 Atom Lite and M5Stamp Pico envs for PDM support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -442,6 +442,43 @@ board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.partitions = tools/SoundReactive_ESP32_16MB.csv
 
+[env:soundReactive_m5atom]
+board = esp32dev
+platform = espressif32@3.2
+upload_speed = 1500000
+monitor_speed = 115200
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags_esp32}
+  -D WLED_RELEASE_NAME=ESP32
+  -D WLED_DISABLE_MQTT
+  -D WLED_DISABLE_LOXONE
+  -D LEDPIN=27
+  -D BTNPIN=39
+  -D DMENABLED=5
+  -D I2S_SDPIN=26
+  -D I2S_WSPIN=32
+  -D I2S_CKPIN=-1
+lib_deps = ${esp32.lib_deps}
+board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+
+[env:soundReactive_m5stamp-pico]
+board = esp32dev
+platform = espressif32@3.2
+upload_speed = 1500000
+monitor_speed = 115200
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags_esp32}
+  -D WLED_RELEASE_NAME=ESP32
+  -D WLED_DISABLE_MQTT
+  -D WLED_DISABLE_LOXONE
+  -D LEDPIN=27
+  -D BTNPIN=39
+  -D DMENABLED=5
+  -D I2S_SDPIN=32
+  -D I2S_WSPIN=33
+  -D I2S_CKPIN=-1
+lib_deps = ${esp32.lib_deps}
+board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 
 # ------------------------------------------------------------------------------
 # custom board configurations


### PR DESCRIPTION
The `esp32dev` env causes a loop crash on the M5 Atom Lite and M5Stamp Pico boards, The default LED pin needs to be set to 27 (the on-board SK6812) in order to flash and boot properly.

This adds two new Sound Reactive envs for the [M5 Atom Lite](https://shop.m5stack.com/products/atom-lite-esp32-development-kit) and [M5Stamp Pico](https://shop.m5stack.com/products/m5stamp-pico-diy-kit) that set the pins for:
- The on-board button
- The on-board SK6812
- The I2S pins for the Grove connector

This should allow you to hook up the [M5 PDM MEMS Microphone](https://shop.m5stack.com/products/pdm-microphone-unit-spm1423) and have it work out of the box.

Note: The [M5Stamp C3](https://shop.m5stack.com/products/m5stamp-c3-mate-with-pin-headers) is a different board with a single-core ESP32 and different pinouts, so will probably need it's own env to work.