### PR TITLE
Analogue mic processing improvements (fixes #167)

### DIFF
--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -24,28 +24,29 @@ void userSetup() {
   switch (dmType) {
     case 1:
       Serial.println("AS: Generic I2S Microphone.");
-      audioSource = new I2SSource(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);
+      audioSource = new I2SSource(SAMPLE_RATE, BLOCK_SIZE, 0, 0xFFFFFFFF);
       break;
     case 2:
       Serial.println("AS: ES7243 Microphone.");
-      audioSource = new ES7243(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);
+      audioSource = new ES7243(SAMPLE_RATE, BLOCK_SIZE, 0, 0xFFFFFFFF);
       break;
     case 3:
       Serial.println("AS: SPH0645 Microphone");
-      audioSource = new SPH0654(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);
+      audioSource = new SPH0654(SAMPLE_RATE, BLOCK_SIZE, 0, 0xFFFFFFFF);
       break;
     case 4:
       Serial.println("AS: Generic I2S Microphone with Master Clock");
-      audioSource = new I2SSourceWithMasterClock(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);
+      audioSource = new I2SSourceWithMasterClock(SAMPLE_RATE, BLOCK_SIZE, 0, 0xFFFFFFFF);
       break;
     case 5:
       Serial.println("AS: I2S PDM Microphone");
-      audioSource = new I2SPdmSource(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFFFFFFF);
+      audioSource = new I2SPdmSource(SAMPLE_RATE, BLOCK_SIZE, 0, 0xFFFFFFFF);
       break;
     case 0:
     default:
       Serial.println("AS: Analog Microphone.");
-      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, 16, 0xFFF);
+      // we don't need the down-shift by 16bit any more
+      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, 0, 0x0FFF);
       break;
   }
 


### PR DESCRIPTION
initial commit, work in progress
* request 16bit samples from I2S
* no start/stop of ADC processing, to avoid ugly artefacts
* I2S buffer size increased
* samples go into FFT as-is, no adjustments to remove DC or take absolute values
* small improvement to FFT: DCRemove, different windowing function
* avoid several "rounds" of abs(), smoothing and DC removal

Comments welcome :-)

Update: found out that ADC samples are 0...4096(unsigned), while all digital mics deliver at least 16bit (signed, int16). Will add some code tomorrow, to "up-scale" ADC samples so they are in the same range as delivered by digital ones.