### PR TITLE
Analogue mic processing part2

### DIFF
--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -185,7 +185,7 @@ public:
                   sample = (double) (samples[i] >> _shift);
                 else {
                   if(_shift < 0)
-                    sample = (double) (samples[i] << (- _shift)); // need to "pup up" 12bit ADC to full 16bit as delivered by other digotal mics
+                    sample = (double) (samples[i] << (- _shift)); // need to "pump up" 12bit ADC to full 16bit as delivered by other digotal mics
                   else
                     sample = (double) samples[i];
                 }

--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -352,7 +352,17 @@ public:
         if (err != ESP_OK) {
             Serial.printf("Failed to set i2s adc mode: %d\n", err);
             return;
+
         }
+#if defined(ARDUINO_ARCH_ESP32)
+        // according to docs from espressif, the ADC needs to be started explicitly
+        // fingers crossed
+        err = i2s_adc_enable(I2S_NUM_0);
+        if (err != ESP_OK) {
+            Serial.printf("Failed to enable i2s adc: %d\n", err);
+            //return;
+        }
+#endif
 
         _initialized = true;
     }
@@ -389,7 +399,17 @@ public:
     void deinitialize() {
         pinManager.deallocatePin(audioPin, PinOwner::AnalogMic);
         _initialized = false;
-        esp_err_t err = i2s_driver_uninstall(I2S_NUM_0);
+        esp_err_t err;
+#if defined(ARDUINO_ARCH_ESP32)
+        // according to docs from espressif, the ADC needs to be stopped explicitly
+        // fingers crossed
+        err = i2s_adc_disable(I2S_NUM_0);
+        if (err != ESP_OK) {
+            Serial.printf("Failed to disable i2s adc: %d\n", err);
+            //return;
+        }
+#endif
+        err = i2s_driver_uninstall(I2S_NUM_0);
         if (err != ESP_OK) {
             Serial.printf("Failed to uninstall i2s driver: %d\n", err);
             return;

--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -185,7 +185,7 @@ public:
                   sample = (double) (samples[i] >> _shift);
                 else {
                   if(_shift < 0)
-                    sample = (double) (samples[i] << (- _shift)); // need to "pump up" 12bit ADC to full 16bit as delivered by other digotal mics
+                    sample = (double) (samples[i] << (- _shift)); // need to "pump up" 12bit ADC to full 16bit as delivered by other digital mics
                   else
                     sample = (double) samples[i];
                 }

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -45,8 +45,8 @@ void userSetup() {
     case 0:
     default:
       Serial.println("AS: Analog Microphone.");
-      // we don't need the down-shift by 16bit any more
-      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, 0, 0x0FFF);
+      // we don't do the down-shift by 16bit any more, however "upscaling" from 12bit to 16bit is needed
+      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, -4, 0x0FFF);
       break;
   }
 

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -45,8 +45,9 @@ void userSetup() {
     case 0:
     default:
       Serial.println("AS: Analog Microphone.");
-      // we don't do the down-shift by 16bit any more, however "upscaling" from 12bit to 16bit is needed
-      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, -4, 0x0FFF);
+      // we don't do the down-shift by 16bit any more
+      //audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, -4, 0x0FFF);  // request upscaling to 16bit - still produces too much noise
+      audioSource = new I2SAdcSource(SAMPLE_RATE, BLOCK_SIZE, 0, 0x0FFF);     // keep at 12bit - less noise
       break;
   }
 


### PR DESCRIPTION
* some improvements to ADC signal sampling
* possibility to up-scale ADC 12bit -> 16bit, as delivered by the digital mics (but still too noisy)
* added a "quick hack" to the "Majorpeak" code, so highest/lowest FFT bins are suppressed
You should see an improvement in the "BINMAP" and "FREQMAP" effects - for example if you clap hands, whistle a tone, or drop your pen onto the desk, there should be a clear reaction now.