### PR TITLE
Full 32bit samples

### DIFF
--- a/wled00/audio_reactive.h
+++ b/wled00/audio_reactive.h
@@ -19,7 +19,7 @@
 #include <driver/i2s.h>
 #include "audio_source.h"
 
-AudioSource *audioSource;
+static AudioSource *audioSource;
 
 // ALL AUDIO INPUT PINS DEFINED IN wled.h AND CONFIGURABLE VIA UI
 
@@ -342,7 +342,7 @@ void transmitAudioData() {
 
 
 // Create FFT object
-arduinoFFT FFT = arduinoFFT( vReal, vImag, samplesFFT, SAMPLE_RATE );
+static arduinoFFT FFT = arduinoFFT( vReal, vImag, samplesFFT, SAMPLE_RATE );
 
 double fftAdd( int from, int to) {
   int i = from;

--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -188,7 +188,8 @@ public:
             for (int i = 0; i < num_samples; i++) {
                 // pre-shift samples down to 16bit
 #ifdef I2S_SAMPLE_DOWNSCALE_TO_16BIT
-                newSamples[i] >>= 16;
+                if (_shift != 0)
+                    newSamples[i] >>= 16;
 #endif
                 double currSample = 0.0;
                 if(_shift > 0)
@@ -197,7 +198,11 @@ public:
                   if(_shift < 0)
                     currSample = (double) (newSamples[i] << (- _shift)); // need to "pump up" 12bit ADC to full 16bit as delivered by other digital mics
                   else
+#ifdef I2S_SAMPLE_DOWNSCALE_TO_16BIT
+                    currSample = (double) newSamples[i] / 65536.0;        // _shift == 0 -> use the chance to keep lower 16bits
+#else
                     currSample = (double) newSamples[i];
+#endif
                 }
                 buffer[i] = currSample;
                 _dcOffset = ((_dcOffset * 31) + currSample) / 32;


### PR DESCRIPTION
* instead of throwing away the lower 16bit of each sample, preserve them as decimal places. Useful details for later amplification.