### PR TITLE
Correct I2S SD PIN allocation (not output) and add debug message

### DIFF
--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -123,7 +123,7 @@ public:
     virtual void initialize() {
 
         if (!pinManager.allocatePin(i2swsPin, true, PinOwner::DigitalMic) ||
-            !pinManager.allocatePin(i2ssdPin, true, PinOwner::DigitalMic)) {
+            !pinManager.allocatePin(i2ssdPin, false, PinOwner::DigitalMic)) {
                 return;
         }
 

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -31,7 +31,7 @@ bool PinManagerClass::deallocatePin(byte gpio, PinOwner tag)
     #endif
     return false;
   }
-  
+
   byte by = gpio >> 3;
   byte bi = gpio - 8*by;
   bitWrite(pinAlloc[by], bi, false);
@@ -105,7 +105,7 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
       continue;
     } else if (isPinAllocated(gpio)) {
       #ifdef WLED_DEBUG
-      DEBUG_PRINT(F("PIN ALLOC: FAIL: IO ")); 
+      DEBUG_PRINT(F("PIN ALLOC: FAIL: IO "));
       DEBUG_PRINT(gpio);
       DEBUG_PRINT(F(" already allocated by "));
       DebugPrintOwnerTag(ownerTag[gpio]);
@@ -133,7 +133,7 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
     bitWrite(pinAlloc[by], bi, true);
     ownerTag[gpio] = tag;
     #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
+    DEBUG_PRINT(F("PIN ALLOC: Pin "));
     DEBUG_PRINT(gpio);
     DEBUG_PRINT(F(" allocated by "));
     DebugPrintOwnerTag(tag);
@@ -146,10 +146,19 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
 bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
 {
   // HW I2C pins have to be allocated using allocateMultiplePins variant since there is always SCL/SDA pair
-  if (!isPinOk(gpio, output) || tag==PinOwner::HW_I2C) return false;
+  if (!isPinOk(gpio, output) || tag==PinOwner::HW_I2C)
+  {
+    #ifdef WLED_DEBUG
+    DEBUG_PRINT(F("PIN ALLOC: Pin "));
+    DEBUG_PRINT(gpio);
+    DEBUG_PRINT(F(" cannot be allocated. Is it output only?"));
+    #endif
+    return false;
+  }
+
   if (isPinAllocated(gpio)) {
     #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
+    DEBUG_PRINT(F("PIN ALLOC: Pin "));
     DEBUG_PRINT(gpio);
     DEBUG_PRINT(F(" already allocated by "));
     DebugPrintOwnerTag(ownerTag[gpio]);
@@ -163,12 +172,12 @@ bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
   bitWrite(pinAlloc[by], bi, true);
   ownerTag[gpio] = tag;
   #ifdef WLED_DEBUG
-  DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
+  DEBUG_PRINT(F("PIN ALLOC: Pin "));
   DEBUG_PRINT(gpio);
   DEBUG_PRINT(F(" allocated by "));
   DebugPrintOwnerTag(tag);
   DEBUG_PRINTLN(F(""));
-  #endif  
+  #endif
 
   return true;
 }
@@ -188,7 +197,7 @@ bool PinManagerClass::isPinOk(byte gpio, bool output)
 {
   if (gpio <  6) return  true;
   if (gpio < 12) return false; //SPI flash pins
-  
+
   #ifdef ESP8266
   if (gpio < 17) return true;
   #else //ESP32

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -31,7 +31,7 @@ bool PinManagerClass::deallocatePin(byte gpio, PinOwner tag)
     #endif
     return false;
   }
-
+  
   byte by = gpio >> 3;
   byte bi = gpio - 8*by;
   bitWrite(pinAlloc[by], bi, false);
@@ -105,7 +105,7 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
       continue;
     } else if (isPinAllocated(gpio)) {
       #ifdef WLED_DEBUG
-      DEBUG_PRINT(F("PIN ALLOC: FAIL: IO "));
+      DEBUG_PRINT(F("PIN ALLOC: FAIL: IO ")); 
       DEBUG_PRINT(gpio);
       DEBUG_PRINT(F(" already allocated by "));
       DebugPrintOwnerTag(ownerTag[gpio]);
@@ -133,7 +133,7 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
     bitWrite(pinAlloc[by], bi, true);
     ownerTag[gpio] = tag;
     #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin "));
+    DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
     DEBUG_PRINT(gpio);
     DEBUG_PRINT(F(" allocated by "));
     DebugPrintOwnerTag(tag);
@@ -146,19 +146,10 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
 bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
 {
   // HW I2C pins have to be allocated using allocateMultiplePins variant since there is always SCL/SDA pair
-  if (!isPinOk(gpio, output) || tag==PinOwner::HW_I2C)
-  {
-    #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin "));
-    DEBUG_PRINT(gpio);
-    DEBUG_PRINT(F(" cannot be allocated. Is it output only?"));
-    #endif
-    return false;
-  }
-
+  if (!isPinOk(gpio, output) || tag==PinOwner::HW_I2C) return false;
   if (isPinAllocated(gpio)) {
     #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin "));
+    DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
     DEBUG_PRINT(gpio);
     DEBUG_PRINT(F(" already allocated by "));
     DebugPrintOwnerTag(ownerTag[gpio]);
@@ -172,12 +163,12 @@ bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
   bitWrite(pinAlloc[by], bi, true);
   ownerTag[gpio] = tag;
   #ifdef WLED_DEBUG
-  DEBUG_PRINT(F("PIN ALLOC: Pin "));
+  DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
   DEBUG_PRINT(gpio);
   DEBUG_PRINT(F(" allocated by "));
   DebugPrintOwnerTag(tag);
   DEBUG_PRINTLN(F(""));
-  #endif
+  #endif  
 
   return true;
 }
@@ -197,7 +188,7 @@ bool PinManagerClass::isPinOk(byte gpio, bool output)
 {
   if (gpio <  6) return  true;
   if (gpio < 12) return false; //SPI flash pins
-
+  
   #ifdef ESP8266
   if (gpio < 17) return true;
   #else //ESP32


### PR DESCRIPTION
The M5 Stick Plus has an internal I2S PDM MIC. The PINs are 34 for SD and 0 for WS. The PIN manager logic is as follows:
```
if (gpio <  6) return  true;
if (gpio < 12) return false; //SPI flash pins
if (gpio < 34) return true;
if (gpio < 40 && !output) return true; //34-39 input only

return false;
```

In the PDM audio source, the PIN request for SD is incorrectly marked as an output PIN, meaning in this IF cascade, the request for PIN 34 reaches the final return false (and thus no PIN assigned). By correcting the request with output=false, the bug is fixed. I was shocked there was no debug message for this either, so I added one.