### PR TITLE
Fixed changing brightness not trigger autosave, added inputLevel as autosave trigger

### DIFF
--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
@@ -40,7 +40,7 @@ class AutoSaveUsermod : public Usermod {
     // If we've detected the need to auto save, this will be non zero.
     unsigned long autoSaveAfter = 0;
 
-    uint8_t knownInputLevel = 0;
+    uint8_t knownInputLevel = 0;  //WLEDSR
     uint8_t knownBrightness = 0;
     uint8_t knownEffectSpeed = 0;
     uint8_t knownEffectIntensity = 0;

--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
@@ -40,6 +40,7 @@ class AutoSaveUsermod : public Usermod {
     // If we've detected the need to auto save, this will be non zero.
     unsigned long autoSaveAfter = 0;
 
+    uint8_t knownInputLevel = 0;
     uint8_t knownBrightness = 0;
     uint8_t knownEffectSpeed = 0;
     uint8_t knownEffectIntensity = 0;
@@ -88,6 +89,7 @@ class AutoSaveUsermod : public Usermod {
       #endif
       initDone = true;
       if (enabled && applyAutoSaveOnBoot) applyPreset(autoSavePreset);
+      knownInputLevel = inputLevel;
       knownBrightness = bri;
       knownEffectSpeed = effectSpeed;
       knownEffectIntensity = effectIntensity;
@@ -110,7 +112,10 @@ class AutoSaveUsermod : public Usermod {
       uint8_t currentPalette = strip.getMainSegment().palette;
 
       unsigned long wouldAutoSaveAfter = now + autoSaveAfterSec*1000;
-      if (knownBrightness != bri) {
+      if (knownInputLevel != inputLevel) {
+        knownInputLevel = inputLevel;
+        autoSaveAfter = wouldAutoSaveAfter;
+      } else if (knownBrightness != bri) {
         knownBrightness = bri;
         autoSaveAfter = wouldAutoSaveAfter;
       } else if (knownEffectSpeed != effectSpeed) {

--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
@@ -89,7 +89,7 @@ class AutoSaveUsermod : public Usermod {
       #endif
       initDone = true;
       if (enabled && applyAutoSaveOnBoot) applyPreset(autoSavePreset);
-      knownInputLevel = inputLevel;
+      knownInputLevel = inputLevel; //WLEDSR
       knownBrightness = bri;
       knownEffectSpeed = effectSpeed;
       knownEffectIntensity = effectIntensity;
@@ -112,9 +112,9 @@ class AutoSaveUsermod : public Usermod {
       uint8_t currentPalette = strip.getMainSegment().palette;
 
       unsigned long wouldAutoSaveAfter = now + autoSaveAfterSec*1000;
-      if (knownInputLevel != inputLevel) {
-        knownInputLevel = inputLevel;
-        autoSaveAfter = wouldAutoSaveAfter;
+      if ((soundAgc == 0) && (knownInputLevel != inputLevel)) {  //begin WLEDSR
+        knownInputLevel = inputLevel; 
+        autoSaveAfter = wouldAutoSaveAfter; //end WLEDSR
       } else if (knownBrightness != bri) {
         knownBrightness = bri;
         autoSaveAfter = wouldAutoSaveAfter;

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -86,7 +86,7 @@ void applyBri() {
   if (!realtimeMode || !arlsForceMaxBri)
   {
     strip.setBrightness(scaledBri(briT));
-    stateChanged = true;
+    stateChanged = true; //WLEDSR
   }
 }
 

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -86,6 +86,7 @@ void applyBri() {
   if (!realtimeMode || !arlsForceMaxBri)
   {
     strip.setBrightness(scaledBri(briT));
+    stateChanged = true;
   }
 }
 

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -86,7 +86,7 @@ void applyBri() {
   if (!realtimeMode || !arlsForceMaxBri)
   {
     strip.setBrightness(scaledBri(briT));
-    stateChanged = true; //WLEDSR
+    stateChanged = true; //WLEDSR temporary fix, until solved in upstream
   }
 }
 


### PR DESCRIPTION
Changing global brightness now triggers the stateChange feature. Added inputLevel as autosave trigger to be able to save inputLevel via autosave usermod.