### PR TITLE
Fix setPixelColor when using 2D + Serpentine

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -308,7 +308,7 @@ void IRAM_ATTR WS2812FX::setPixelColor(uint16_t i, byte r, byte g, byte b, byte 
     }
   } else {
     if (i < customMappingSize) i = customMappingTable[i];
-    busses.setPixelColor(i, RGBW32(r, g, b, w));
+    // busses.setPixelColor(i, RGBW32(r, g, b, w));
     busses.setPixelColor(logicalToPhysical(i), RGBW32(r, g, b, w)); // ewowi20210624: logicalToPhysical: Maps logical led index to physical led index.
   }
 }


### PR DESCRIPTION
When streaming, or using WS2812FX::setPixelColor with a 2D panel with serpentine on, WLED creates a pixel twice on left and right of every other row(kind of mirrors it).
so,

line I commented: assumes the strip is laid out left to right every row
line below: knows the strip is laid out in a serpentine(or whatever other way it is set)
and they both run and create the mirror every other line, when they don't overlap

so this fixes that