### PR TITLE
Export wiki to pages for better SEO using Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Publish WIKI to pages
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.5.0
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'atuline/WLED.wiki'
+      - name: show files
+        run: find ./
+      - name: build docs
+        run: npm install -g github-wikito-converter && mkdir _site && gwtc --output _site/ --file-name index ./
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+# Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,7 @@ name: Publish WIKI to pages
 
 # Controls when the workflow will run
 on:
+  push:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Github actively block indexing of any of the wiki, which makes finding information harder than it should be (https://github.com/orgs/community/discussions/4992)

Solution - Run export to static HTML and host on GitHub pages