### PR TITLE
Additional guard delay after i2s_driver_uninstall

### DIFF
--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -26,6 +26,7 @@ void userSetup() {
   disableSoundProcessing = true; // just to be safe
   // Reset I2S peripheral for good measure
   i2s_driver_uninstall(I2S_NUM_0);
+  delay(100); // Give this peripheral time to disable to avoid an indeterminate state.
   periph_module_reset(PERIPH_I2S0_MODULE);
 
   delay(100);         // Give that poor microphone some time to setup.


### PR DESCRIPTION
Solving the problem of initialization of an I2S peripheral, in which it may be in an indeterminate state after a soft reset, in which the analog microphone does not work.