### PR TITLE
Reset I2S peripheral for analog microphone.

### DIFF
--- a/wled00/audio_source.h
+++ b/wled00/audio_source.h
@@ -9,6 +9,11 @@
 #include <driver/adc_types_deprecated.h>
 #endif
 
+#include "soc/rtc_cntl_reg.h"
+#include "soc/sens_reg.h"
+#include "soc/syscon_reg.h"
+#include "soc/i2s_reg.h"
+
 //#include <driver/i2s_std.h>
 //#include <driver/i2s_pdm.h>
 //#include <driver/gpio.h>

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -30,7 +30,6 @@ void userSetup() {
   disableSoundProcessing = true; // just to be safe
   // Reset I2S peripheral for good measure
   i2s_driver_uninstall(I2S_NUM_0);
-  delay(100); // Give this peripheral time to disable to avoid an indeterminate state.
   periph_module_reset(PERIPH_I2S0_MODULE);
 
   delay(100);         // Give that poor microphone some time to setup.


### PR DESCRIPTION
Solving the analog microphone problem as we reset entire I2S peripheral, may which it may be in an indeterminate state after a soft reset, in which the microphone does not work.

This variant of peripheral reset, using the register write sequence as in the bootloader_random_disable function of the esp-idf bootloader_support component, gave excellent results after many hours of testing with a cyclic soft reset.