### PR TITLE
Audio palette always start with black

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1356,27 +1356,32 @@ void WS2812FX::handle_palette(void)
 CRGBPalette16 WS2812FX::getAudioPalette(int pal) {
   // https://forum.makerforums.info/t/hi-is-it-possible-to-define-a-gradient-palette-at-runtime-the-define-gradient-palette-uses-the/63339
 
-  uint8_t xyz[12];  // Needs to be 4 times however many colors are being used.
+  uint8_t xyz[16];  // Needs to be 4 times however many colors are being used.
                     // 3 colors = 12, 4 colors = 16, etc.
 
-  CRGB rgb = getCRGBForBand(0, pal);
-  
   xyz[0] = 0;  // anchor of first color - must be zero
-  xyz[1] = rgb.r;
-  xyz[2] = rgb.g;
-  xyz[3] = rgb.b;
+  xyz[1] = 0;
+  xyz[2] = 0;
+  xyz[3] = 0;
 
-  rgb = getCRGBForBand(4, pal);
-  xyz[4] = 128;
+  CRGB rgb = getCRGBForBand(1, pal);
+  
+  xyz[4] = 1;  // anchor of first color
   xyz[5] = rgb.r;
   xyz[6] = rgb.g;
   xyz[7] = rgb.b;
-  
-  rgb = getCRGBForBand(8, pal);
-  xyz[8] = 255;  // anchor of last color - must be 255
+
+  rgb = getCRGBForBand(4, pal);
+  xyz[8] = 128;
   xyz[9] = rgb.r;
   xyz[10] = rgb.g;
   xyz[11] = rgb.b;
+  
+  rgb = getCRGBForBand(8, pal);
+  xyz[12] = 255;  // anchor of last color - must be 255
+  xyz[13] = rgb.r;
+  xyz[14] = rgb.g;
+  xyz[15] = rgb.b;
 
   return CRGBPalette16(xyz);
 }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1371,13 +1371,13 @@ CRGBPalette16 WS2812FX::getAudioPalette(int pal) {
   xyz[6] = rgb.g;
   xyz[7] = rgb.b;
 
-  rgb = getCRGBForBand(4, pal);
+  rgb = getCRGBForBand(128, pal);
   xyz[8] = 128;
   xyz[9] = rgb.r;
   xyz[10] = rgb.g;
   xyz[11] = rgb.b;
   
-  rgb = getCRGBForBand(8, pal);
+  rgb = getCRGBForBand(255, pal);
   xyz[12] = 255;  // anchor of last color - must be 255
   xyz[13] = rgb.r;
   xyz[14] = rgb.g;

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -84,7 +84,7 @@ CRGB getCRGBForBand(int x, int pal) {
     } 
   }
   else if(pal == 72) {
-    int b = map(x, 0, 255, 0, 8); // convert palette position to lower half of freq band
+    int b = map(x, 1, 255, 0, 8); // convert palette position to lower half of freq band
     hsv = CHSV(uint8_t(fftResult[b]), 255, uint8_t(map(fftResult[b], 0, 255, 30, 255)));  // pick hue
     hsv2rgb_rainbow(hsv, value);  // convert to R,G,B
   }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -73,7 +73,7 @@ CRGB getCRGBForBand(int x, int pal) {
   CRGB value;
   CHSV hsv;
   if(pal == 71) { // bit hacky to use palette id here, but don't want to litter the code with lots of different methods. TODO: add enum for palette creation type
-    if(x == 0) {
+    if(x == 1) {
       value = CRGB(uint8_t(fftResult[10]/2), uint8_t(fftResult[4]/2), uint8_t(fftResult[0]/2));
     }
     else if(x == 255) {


### PR DESCRIPTION
to fix fire effect. Also fixes the spacing of the palette over the fftResults for AR Hue